### PR TITLE
Fix model loading

### DIFF
--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from unet3d.data import add_data_to_storage, create_data_file
 from unet3d.generator import get_multi_class_labels, get_training_and_validation_generators
-from unet3d.augment import generate_permutation_keys, permute_data
+from unet3d.augment import generate_permutation_keys, permute_data, reverse_permute_data
 
 
 class TestDataGenerator(TestCase):
@@ -192,3 +192,11 @@ class TestDataGenerator(TestCase):
             break
 
         self.rm_tmp_files()
+
+    def test_reverse_permutation(self):
+        data_shape = (4, 32, 32, 32)
+        data = np.arange(np.prod(data_shape)).reshape(data_shape)
+        for permutation_key in generate_permutation_keys():
+            permuted_data = permute_data(data, permutation_key)
+            reversed_permutation = reverse_permute_data(permuted_data, permutation_key)
+            self.assertTrue(np.all(data == reversed_permutation))

--- a/unet3d/augment.py
+++ b/unet3d/augment.py
@@ -114,10 +114,11 @@ def permute_data(data, key):
     """
     data = np.copy(data)
     (rotate_y, rotate_z), flip_x, flip_y, flip_z, transpose = key
-    if rotate_y:
-        data = np.rot90(data, axes=(1, 3))
-    if rotate_z:
-        data = np.rot90(data, axes=(2, 3))
+
+    if rotate_y != 0:
+        data = np.rot90(data, rotate_y, axes=(1, 3))
+    if rotate_z != 0:
+        data = np.rot90(data, rotate_z, axes=(2, 3))
     if flip_x:
         data = data[:, ::-1]
     if flip_y:
@@ -139,3 +140,29 @@ def random_permutation_x_y(x_data, y_data):
     """
     key = random_permutation_key()
     return permute_data(x_data, key), permute_data(y_data, key)
+
+
+def reverse_permute_data(data, key):
+    key = reverse_permutation_key(key)
+    data = np.copy(data)
+    (rotate_y, rotate_z), flip_x, flip_y, flip_z, transpose = key
+
+    if transpose:
+        for i in range(data.shape[0]):
+            data[i] = data[i].T
+    if flip_z:
+        data = data[:, :, :, ::-1]
+    if flip_y:
+        data = data[:, :, ::-1]
+    if flip_x:
+        data = data[:, ::-1]
+    if rotate_z != 0:
+        data = np.rot90(data, rotate_z, axes=(2, 3))
+    if rotate_y != 0:
+        data = np.rot90(data, rotate_y, axes=(1, 3))
+    return data
+
+
+def reverse_permutation_key(key):
+    rotation = tuple([-rotate for rotate in key[0]])
+    return rotation, key[1], key[2], key[3], key[4]

--- a/unet3d/prediction.py
+++ b/unet3d/prediction.py
@@ -161,5 +161,5 @@ def predict_with_permutations(model, data):
     predictions = list()
     for permutation_key in generate_permutation_keys():
         temp_data = permute_data(data, permutation_key)
-        predictions.append(reverse_permute_data(model.predict(temp_data), permutation_key))
+        predictions.append(reverse_permute_data(model.predict([temp_data]), permutation_key))
     return np.mean(predictions, axis=0)

--- a/unet3d/prediction.py
+++ b/unet3d/prediction.py
@@ -161,5 +161,5 @@ def predict_with_permutations(model, data):
     predictions = list()
     for permutation_key in generate_permutation_keys():
         temp_data = permute_data(data, permutation_key)[np.newaxis]
-        predictions.append(reverse_permute_data(model.predict(temp_data), permutation_key))
+        predictions.append(reverse_permute_data(model.predict(temp_data)[0], permutation_key))
     return np.mean(predictions, axis=0)

--- a/unet3d/prediction.py
+++ b/unet3d/prediction.py
@@ -160,6 +160,6 @@ def predict(model, data, permute=False):
 def predict_with_permutations(model, data):
     predictions = list()
     for permutation_key in generate_permutation_keys():
-        temp_data = permute_data(data, permutation_key)
-        predictions.append(reverse_permute_data(model.predict([temp_data]), permutation_key))
+        temp_data = permute_data(data, permutation_key)[np.newaxis]
+        predictions.append(reverse_permute_data(model.predict(temp_data), permutation_key))
     return np.mean(predictions, axis=0)

--- a/unet3d/prediction.py
+++ b/unet3d/prediction.py
@@ -7,7 +7,7 @@ import tables
 from .training import load_old_model
 from .utils import pickle_load
 from .utils.patches import reconstruct_from_patches, get_patch_from_3d_data, compute_patch_indices
-from .augment import permute_data, generate_permutation_keys
+from .augment import permute_data, generate_permutation_keys, reverse_permute_data
 
 
 def patch_wise_prediction(model, data, overlap=0, batch_size=1, permute=False):
@@ -158,5 +158,5 @@ def predict_with_permutations(model, data):
     predictions = list()
     for permutation_key in generate_permutation_keys():
         temp_data = permute_data(data, permutation_key)
-        predictions.append(model.predict(temp_data))
+        predictions.append(reverse_permute_data(model.predict(temp_data), permutation_key))
     return np.mean(predictions, axis=0)

--- a/unet3d/prediction.py
+++ b/unet3d/prediction.py
@@ -149,7 +149,10 @@ def run_validation_case(test_index, out_dir, model_file, hdf5_file, validation_k
 
 def predict(model, data, permute=False):
     if permute:
-        return predict_with_permutations(model, data)
+        predictions = list()
+        for batch_index in range(data.shape[0]):
+            predictions.append(predict_with_permutations(model, data[batch_index]))
+        return np.asarray(predictions)
     else:
         return model.predict(data)
 

--- a/unet3d/training.py
+++ b/unet3d/training.py
@@ -44,7 +44,14 @@ def load_old_model(model_file):
         custom_objects["InstanceNormalization"] = InstanceNormalization
     except ImportError:
         pass
-    return load_model(model_file, custom_objects=custom_objects)
+    try:
+        return load_model(model_file, custom_objects=custom_objects)
+    except ValueError as error:
+        if 'InstanceNormalization' in str(error):
+            raise ValueError(str(error) + "\n\nPlease install keras-contrib to use InstanceNormalization:\n"
+                                          "'pip install git+https://www.github.com/keras-team/keras-contrib.git'")
+        else:
+            raise error
 
 
 def train_model(model, model_file, training_generator, validation_generator, steps_per_epoch, validation_steps,

--- a/unet3d/training.py
+++ b/unet3d/training.py
@@ -39,6 +39,11 @@ def load_old_model(model_file):
                       'dice_coef': dice_coef, 'dice_coef_loss': dice_coef_loss,
                       'weighted_dice_coefficient': weighted_dice_coefficient,
                       'weighted_dice_coefficient_loss': weighted_dice_coefficient_loss}
+    try:
+        from keras_contrib.layers import InstanceNormalization
+        custom_objects["InstanceNormalization"] = InstanceNormalization
+    except ImportError:
+        pass
     return load_model(model_file, custom_objects=custom_objects)
 
 


### PR DESCRIPTION
Installing [keras-contrib](https://github.com/keras-team/keras-contrib) is necessary for using the Isensee model. Adds helpful error message when keras-contrib is not installed and a model is loaded that uses InstanceNormalization.

Fixes #73, #78 
