### PR TITLE
fix typo in autoimplant2020 README.md

### DIFF
--- a/examples/autoimplant2020/README.md
+++ b/examples/autoimplant2020/README.md
@@ -5,9 +5,9 @@ git clone https://github.com/ellisdg/3DUnetCNN.git
 cd 3DUnetCNN
 export PYTHONPATH=${PWD}:${PYTHONPATH}
 ``` 
-2. ```cd``` into the ```brats2020``` example directory:
+2. ```cd``` into the ```autoimplant2020``` example directory:
 
-```cd examples/brats2020``` 
+```cd examples/autoimplant2020``` 
 
 3. Download the augmented dataset and un-archive it into the current directory ("examples/autoimplant2020"):
 


### PR DESCRIPTION
I think there might be a typo in example/autoimplant2020/README.md.

By the way, thanks for the awesome project!