### PR TITLE
FIX: renames UNet to UNet3D

### DIFF
--- a/unet3d/models/pytorch/__init__.py
+++ b/unet3d/models/pytorch/__init__.py
@@ -1,4 +1,5 @@
+from monai.networks.nets import *
 from .classification.resnet import *
 from .classification.custom import *
 from .segmentation.unet import *
-from monai.networks.nets import *
+

--- a/unet3d/models/pytorch/segmentation/unet.py
+++ b/unet3d/models/pytorch/segmentation/unet.py
@@ -35,13 +35,13 @@ class UNetDecoder(MirroredDecoder):
         return x
 
 
-class UNet(ConvolutionalAutoEncoder):
+class UNet3D(ConvolutionalAutoEncoder):
     def __init__(self, *args, encoder_class=UNetEncoder, decoder_class=UNetDecoder, n_outputs=1, **kwargs):
         super().__init__(*args, encoder_class=encoder_class, decoder_class=decoder_class, n_outputs=n_outputs, **kwargs)
         self.set_final_convolution(n_outputs=n_outputs)
 
 
-class AutocastUNet(UNet):
+class AutocastUNet(UNet3D):
     def forward(self, *args, **kwargs):
         from torch.cuda.amp import autocast
         with autocast():
@@ -49,7 +49,7 @@ class AutocastUNet(UNet):
         return output
 
 
-class AutoImplantUNet(UNet):
+class AutoImplantUNet(UNet3D):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
The UNet class overlapped with that of MONAI, so I renamed the one for this repository so that users could use either.