### PR TITLE
FIX: sets default prefetch factor to 1

### DIFF
--- a/unet3d/scripts/script_utils.py
+++ b/unet3d/scripts/script_utils.py
@@ -154,7 +154,7 @@ def fetch_inference_dataset_kwargs_from_config(config):
     inference_dataset_kwargs = in_config("validation", config["dataset"], dict())
     batch_size = in_config("validation_batch_size", config["training"], 1)
     # TODO: figure out the best setting for prefetch_factor
-    prefetch_factor = in_config("prefetch_factor", config["training"], None)
+    prefetch_factor = in_config("prefetch_factor", config["training"], 1)
     return inference_dataset_kwargs, batch_size, prefetch_factor
 
 


### PR DESCRIPTION
Prefetch factor was set to None by default for inference which raises an error during prediction. Changed the default to 1 which is the same as training.

Closes #341 